### PR TITLE
Remove header lines from ASCII grids for cdo command

### DIFF
--- a/landuse/HYDE/step2_hyde_convert.sh
+++ b/landuse/HYDE/step2_hyde_convert.sh
@@ -51,11 +51,13 @@ for IDIR in $ASCIIDIR/*_$TYPE;do
     echo " $FILE $VAR $CAL $YEAR ..."
     ## This keeps trying until files are converted successfully.
     while [ ! -f $ODIR/${VAR}_$YEAR.nc4 ];do
+      # Remove 6 line header from .asc files
+      tail -n +7 $FILE |\
       cdo --history -m -9999 -f nc4c -z zip -s \
           -setreftime,$STARTYEAR-01-01,00:00:00,1years \
           -settaxis,$YEAR-01-01,00:00:00,1years \
           -setname,$VAR -setmissval,1E+20 -invertlatdata -setunit,km^2 \
-          -input,grid.txt $ODIR/${VAR}_$YEAR.nc4 < $FILE
+          -input,grid.txt $ODIR/${VAR}_$YEAR.nc4
     done
   done
 done


### PR DESCRIPTION
When trying to run this script I got an error like `Too few input elements (9331199 of 9331200)!`. I found this https://code.mpimet.mpg.de/boards/1/topics/14564 which suggests the input files should not have headers. Removing them seems to make the `cdo` command work again.